### PR TITLE
Fix copyright and mail address

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,7 +9,7 @@ use MyBuilder;
 my $builder = MyBuilder->new(
   module_name => 'Net::CIDR::Set',
   license     => 'perl',
-  dist_author => 'Andy Armstrong <andy.armstrong@messagesystems.com>',
+  dist_author => 'Andy Armstrong <andy@hexten.net>',
   dist_version_from => 'lib/Net/CIDR/Set.pm',
   requires          => { 'Test::More' => 0 },
   add_to_cleanup    => ['Net-CIDR-Set-*'],

--- a/META.yml
+++ b/META.yml
@@ -4,7 +4,7 @@ version: 0.13
 
 
 author:
-  - 'Andy Armstrong <andy.armstrong@messagesystems.com>'
+  - 'Andy Armstrong <andy@hexten.net>'
 abstract: Manipulate sets of IP addresses
 license: perl
 resources:

--- a/lib/Net/CIDR/Set.pm
+++ b/lib/Net/CIDR/Set.pm
@@ -793,30 +793,3 @@ This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See L<perlartistic>.
 
 Copyright (c) 2009, Message Systems, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or
-without modification, are permitted provided that the following
-conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in
-      the documentation and/or other materials provided with the
-      distribution.
-    * Neither the name Message Systems, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/Net/CIDR/Set.pm
+++ b/lib/Net/CIDR/Set.pm
@@ -780,7 +780,7 @@ __END__
 
 =head1 AUTHOR
 
-Andy Armstrong  C<< <andy.armstrong@messagesystems.com> >>
+Andy Armstrong  C<< <andy@hexten.net> >>
 
 =head1 CREDITS
 

--- a/lib/Net/CIDR/Set/IPv4.pm
+++ b/lib/Net/CIDR/Set/IPv4.pm
@@ -115,30 +115,3 @@ This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See L<perlartistic>.
 
 Copyright (c) 2009, Message Systems, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or
-without modification, are permitted provided that the following
-conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in
-      the documentation and/or other materials provided with the
-      distribution.
-    * Neither the name Message Systems, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/Net/CIDR/Set/IPv4.pm
+++ b/lib/Net/CIDR/Set/IPv4.pm
@@ -107,7 +107,7 @@ __END__
 
 =head1 AUTHOR
 
-Andy Armstrong  C<< <andy.armstrong@messagesystems.com> >>
+Andy Armstrong  C<< <andy@hexten.net> >>
 
 =head1 LICENCE AND COPYRIGHT
 

--- a/lib/Net/CIDR/Set/IPv6.pm
+++ b/lib/Net/CIDR/Set/IPv6.pm
@@ -139,7 +139,7 @@ __END__
 
 =head1 AUTHOR
 
-Andy Armstrong  C<< <andy.armstrong@messagesystems.com> >>
+Andy Armstrong  C<< <andy@hexten.net> >>
 
 =head1 LICENCE AND COPYRIGHT
 

--- a/lib/Net/CIDR/Set/IPv6.pm
+++ b/lib/Net/CIDR/Set/IPv6.pm
@@ -147,30 +147,3 @@ This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See L<perlartistic>.
 
 Copyright (c) 2009, Message Systems, Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or
-without modification, are permitted provided that the following
-conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in
-      the documentation and/or other materials provided with the
-      distribution.
-    * Neither the name Message Systems, Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
-IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Hi Andy!
In your mail you wrote, that the BSD clause in the source files wasn't intended, but Net::CIDR::Set should be under Perl Artistic license.
Here's a little patch to fix this.
In addition I changed your mail address, since the messagesystems.com one bounces.
Greetings
Roland